### PR TITLE
Add a btclog.Backend getter

### DIFF
--- a/daemon/log.go
+++ b/daemon/log.go
@@ -179,3 +179,7 @@ func (c logClosure) String() string {
 func newLogClosure(c func() string) logClosure {
 	return logClosure(c)
 }
+
+func BackendLog() (*btclog.Backend) {
+	return backendLog
+}


### PR DESCRIPTION
Enables lightningmobile to add its own logging to the common backend which writes to stdout and a rolling logfile