### PR TITLE
Server: make maximum backoff configurable

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -51,6 +51,7 @@ const (
 	defaultInactiveChanTimeout = 20 * time.Minute
 	defaultMaxLogFiles         = 3
 	defaultMaxLogFileSize      = 10
+	defaultMaxBackoff          = time.Hour
 
 	defaultTorSOCKSPort            = 9050
 	defaultTorDNSHost              = "soa.nodes.lightning.directory"
@@ -195,6 +196,7 @@ type config struct {
 	ExternalIPs      []net.Addr
 	DisableListen    bool `long:"nolisten" description:"Disable listening for incoming peer connections"`
 	NAT              bool `long:"nat" description:"Toggle NAT traversal support (using either UPnP or NAT-PMP) to automatically advertise your external IP address to the network -- NOTE this does not support devices behind multiple NATs"`
+	MaxBackoff       time.Duration `long:"maxbackoff" description:"Longest backoff when reconnecting to persistent peers. Valid time units are {s, m, h}."`
 
 	DebugLevel string `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
 
@@ -293,6 +295,7 @@ func loadConfig(args []string) (*config, error) {
 		},
 		MaxPendingChannels: defaultMaxPendingChannels,
 		NoSeedBackup:       defaultNoSeedBackup,
+		MaxBackoff:         defaultMaxBackoff,
 		Autopilot: &autoPilotConfig{
 			MaxChannels:    5,
 			Allocation:     0.6,

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -49,10 +49,6 @@ const (
 	// reconnecting to persistent peers.
 	defaultBackoff = time.Second
 
-	// maximumBackoff is the largest backoff we will permit when
-	// reattempting connections to persistent peers.
-	maximumBackoff = time.Hour
-
 	// defaultStableConnDuration is a floor under which all reconnection
 	// attempts will apply exponential randomized backoff. Connections
 	// durations exceeding this value will be eligible to have their
@@ -68,6 +64,10 @@ var (
 	// ErrServerShuttingDown indicates that the server is in the process of
 	// gracefully exiting.
 	ErrServerShuttingDown = errors.New("server is shutting down")
+
+	// maximumBackoff is the largest backoff we will permit when
+	// reattempting connections to persistent peers.
+	maximumBackoff = cfg.MaxBackoff
 )
 
 // server is the main server of the Lightning Network Daemon. The server houses


### PR DESCRIPTION
In case of spotty wifi coverage a mobile device will rapidly switch from wifi to 4G and vice versa. In these cases the persistent peer will disconnect and the backoff period will increase exponentially. After a couple reconnects we are talking about minutes which makes for bad user experience.