### PR TITLE
defer ready event to after server starts.

### DIFF
--- a/daemon/lnd.go
+++ b/daemon/lnd.go
@@ -369,10 +369,6 @@ func LndMain(args []string, readyChan chan interface{}) error {
 			rpcsLog.Infof("RPC server listening on %s", memoryRPCListener.Addr())
 			grpcServer.Serve(memoryRPCListener)
 		}()
-		if readyChan != nil {
-			readyChan <- struct{}{}
-		}
-		atomic.StoreInt32(&ready, 1)
 	}
 
 	// Finally, start the REST proxy for our gRPC server above.
@@ -447,6 +443,11 @@ func LndMain(args []string, readyChan chan interface{}) error {
 		return err
 	}
 	defer server.Stop()
+
+	if readyChan != nil {
+		readyChan <- struct{}{}
+	}
+	atomic.StoreInt32(&ready, 1)
 
 	// Now that the server has started, if the autopilot mode is currently
 	// active, then we'll initialize a fresh instance of it and start it.


### PR DESCRIPTION
In this PR we defer the ready event to after the server starts instead of right after the RPC interface is ready.
This will make sure we can safely connect from outside to external peers.