### PR TITLE
change signal package to support subsequently runs.

### DIFF
--- a/daemon/lnd.go
+++ b/daemon/lnd.go
@@ -101,6 +101,13 @@ var (
 // defers created in the top-level scope of a main method aren't executed if
 // os.Exit() is called.
 func LndMain(args []string, readyChan chan interface{}) error {
+
+	//Start the signal that is responsible for shutdown
+	if err := signal.Start(); err != nil {
+		ltndLog.Errorf("failed to start signal %v", err)
+		return err
+	}
+
 	// Load the configuration, and parse any command line options. This
 	// function will also set up logging properly.
 	loadedConfig, err := loadConfig(args)

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -6,8 +6,10 @@
 package signal
 
 import (
+	"errors"
 	"os"
 	"os/signal"
+	"sync/atomic"
 )
 
 var (
@@ -19,15 +21,34 @@ var (
 	shutdownRequestChannel = make(chan struct{})
 
 	// quit is closed when instructing the main interrupt handler to exit.
-	quit = make(chan struct{})
+	quit chan struct{}
 
 	// shutdownChannel is closed once the main interrupt handler exits.
-	shutdownChannel = make(chan struct{})
+	shutdownChannel chan struct{}
+
+	running int32
 )
 
 func init() {
 	signal.Notify(interruptChannel, os.Interrupt)
+}
+
+//Start starts the signal go routine and make it usable again.
+func Start() error {
+
+	if !atomic.CompareAndSwapInt32(&running, 0, 1) {
+		return errors.New("Signal already running")
+	}
+
+	// quit is closed when instructing the main interrupt handler to exit.
+	quit = make(chan struct{})
+
+	// shutdownChannel is closed once the main interrupt handler exits.
+	shutdownChannel = make(chan struct{})
+
 	go mainInterruptHandler()
+
+	return nil
 }
 
 // mainInterruptHandler listens for SIGINT (Ctrl+C) signals on the
@@ -56,6 +77,7 @@ func mainInterruptHandler() {
 		// Signal the main interrupt handler to exit, and stop accept
 		// post-facto requests.
 		close(quit)
+		atomic.StoreInt32(&running, 0)
 	}
 
 	for {
@@ -78,12 +100,7 @@ func mainInterruptHandler() {
 
 // Alive returns true if the main interrupt handler has not been killed.
 func Alive() bool {
-	select {
-	case <-quit:
-		return false
-	default:
-		return true
-	}
+	return atomic.LoadInt32(&running) == 1
 }
 
 // RequestShutdown initiates a graceful shutdown from the application.


### PR DESCRIPTION
This PR is to enable running LND subsequently as library.
Before, the signal was able to be used only one time and this PR makes it re-usable across re-runs.