### PR TITLE
Remove simnet specific code

### DIFF
--- a/daemon/lnd.go
+++ b/daemon/lnd.go
@@ -409,7 +409,7 @@ func LndMain(args []string, readyChan chan interface{}) error {
 	// continue the start up of the remainder of the daemon. This ensures
 	// that we don't accept any possibly invalid state transitions, or
 	// accept channels with spent funds.
-	if !(cfg.Bitcoin.SimNet || cfg.Litecoin.SimNet) {
+	if !cfg.Litecoin.SimNet {
 		_, bestHeight, err := activeChainControl.chainIO.GetBestBlock()
 		if err != nil {
 			return err


### PR DESCRIPTION
Remove simnet specific code that allows to complete initialization (including initial rescan) before syncToChain.