### PR TITLE
initialize bestHeight as was before commenting the synchGraphWithChain

### DIFF
--- a/routing/router.go
+++ b/routing/router.go
@@ -400,6 +400,10 @@ func (r *ChannelRouter) Start() error {
 	// Before we begin normal operation of the router, we first need to
 	// synchronize the channel graph to the latest state of the UTXO set.
 
+	//This is the missing logic that we need from syncGraphWithChain that
+	// that we commented out.
+	r.bestHeight = uint32(bestHeight)
+
 	/* Skip syncGraphWithChain
 	if err := r.syncGraphWithChain(); err != nil {
 		return err


### PR DESCRIPTION
This PR brings back the logic that we commented out when commenting the synchWithChain function on router start.
The best block was initialized there, needed for the functioning of the router when getting network updates.