### PR TITLE
Add mechanism for LND caller to provide its own dependencies.

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -822,11 +822,14 @@ func loadConfig(args []string) (*config, error) {
 		os.Exit(0)
 	}
 
-	// Initialize logging at the default logging level.
-	initLogRotator(
-		filepath.Join(cfg.LogDir, defaultLogFilename),
-		cfg.MaxLogFileSize, cfg.MaxLogFiles,
-	)
+	// Check if we haven't got any injected io.PipeWriter for logging
+	if logWriter.RotatorPipe == nil {
+		// Initialize logging at the default logging level.
+		initLogRotator(
+			filepath.Join(cfg.LogDir, defaultLogFilename),
+			cfg.MaxLogFileSize, cfg.MaxLogFiles,
+		)
+	}
 
 	// Parse, validate, and set debug log level(s).
 	if err := parseAndSetDebugLevels(cfg.DebugLevel); err != nil {


### PR DESCRIPTION
Currently have the following deps:
1. ReadyChan - for signaling ready
2. LogPipeWriter - for shared logging
3. ChainService - for neutrino backend.