### PR TITLE
Optimize pruning zombie channels.

### DIFF
--- a/routing/router.go
+++ b/routing/router.go
@@ -649,10 +649,15 @@ func (r *ChannelRouter) pruneZombieChans() error {
 	r.rejectMtx.Lock()
 	defer r.rejectMtx.Unlock()
 
-	err := r.cfg.Graph.ForEachChannel(filterPruneChans)
+	startTime := time.Unix(0, 0)
+	endTime := time.Now().Add(-1 * chanExpiry)
+	updates, err := r.cfg.Graph.ChanUpdatesInHorizon(startTime, endTime)
 	if err != nil {
 		return fmt.Errorf("Unable to filter local zombie "+
 			"chans: %v", err)
+	}
+	for _, u := range updates {
+		filterPruneChans(u.Info, u.Policy1, u.Policy2)
 	}
 
 	log.Infof("Pruning %v Zombie Channels", len(chansToPrune))
@@ -668,6 +673,8 @@ func (r *ChannelRouter) pruneZombieChans() error {
 				"chans: %v", err)
 		}
 	}
+
+	log.Infof("Pruning %v Zombie Channels finished", len(chansToPrune))
 
 	return nil
 }

--- a/routing/router.go
+++ b/routing/router.go
@@ -425,6 +425,12 @@ func (r *ChannelRouter) Start() error {
 	}
 
 	r.wg.Add(1)
+
+	// prune zombie chans before start
+	if err = r.pruneZombieChans(); err != nil {
+		return err
+	}
+
 	go r.networkHandler()
 
 	return nil
@@ -590,7 +596,7 @@ func (r *ChannelRouter) syncGraphWithChain() error {
 // been updated since our zombie horizon. We do this periodically to keep a
 // health, lively routing table.
 func (r *ChannelRouter) pruneZombieChans() error {
-	var chansToPrune []wire.OutPoint
+	var chansToPrune []*channeldb.ChannelEdgeInfo
 	chanExpiry := r.cfg.ChannelPruneExpiry
 
 	log.Infof("Examining Channel Graph for zombie channels")
@@ -635,7 +641,7 @@ func (r *ChannelRouter) pruneZombieChans() error {
 
 			// TODO(roasbeef): add ability to delete single
 			// directional edge
-			chansToPrune = append(chansToPrune, info.ChannelPoint)
+			chansToPrune = append(chansToPrune, info)
 
 			// As we're detecting this as a zombie channel, we'll
 			// add this to the set of recently rejected items so we
@@ -667,7 +673,13 @@ func (r *ChannelRouter) pruneZombieChans() error {
 	for _, chanToPrune := range chansToPrune {
 		log.Tracef("Pruning zombie chan ChannelPoint(%v)", chanToPrune)
 
-		err := r.cfg.Graph.DeleteChannelEdge(&chanToPrune)
+		var err error
+		if r.cfg.AssumeChannelValid {
+			err = r.cfg.Graph.DeleteChannelEdgeByID(chanToPrune.ChannelID)
+		} else {
+			err = r.cfg.Graph.DeleteChannelEdge(&chanToPrune.ChannelPoint)
+		}
+
 		if err != nil {
 			return fmt.Errorf("Unable to prune zombie "+
 				"chans: %v", err)


### PR DESCRIPTION
This commit introduces a different, more optimized, approach to prune zombie channels.
"zombie channels" stands for channels that their last channel policy update time was earlier than "channel expiry", configured by default to a period of 14 days.
The current approach iterates all channels in the graph in order to filter those in need. This approach is time consuming, several seconds on my mobile device for ~40,000 channels, while during this time the
db is locked in a transaction.

The proposed change is to use an existing functionality that utilize the fact that channel update are saved indexed by date. This way enables us to go over only a small subset of the channels, only those that were updated before the "channel expiry" time and further filter them for our need.
The same graph that took several seconds to prune was pruned, after the change in several milliseconds.

Currently the pruneZombieChans is running every hour, I think that the performance improvement will safely allow to run it on every restart and make sure LND starts up with no zombie channels.

My measurements for ~40,000 channels.

Samsung galaxy s7
prune time before change: 5-12 seconds, depends on the current load.
prune time after change: 15 milliseconds.

Mac book pro 2.8 GHz Intel Core i7
prune time before change: ~400 milliseconds
prune time after change: 15 milliseconds.